### PR TITLE
Add world load event to refresh configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.4.2"
-group= "editmobdrops"
+version = "1.4.3"
+group = "editmobdrops"
 archivesBaseName = "editmobdrops-1.7.10"
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8'
 

--- a/src/main/java/editmobdrops/AddedDrop.java
+++ b/src/main/java/editmobdrops/AddedDrop.java
@@ -1,14 +1,5 @@
 package editmobdrops;
 
-import cpw.mods.fml.common.registry.GameRegistry;
-import editmobdrops.handlers.ConfigHandler;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityList;
-import net.minecraft.item.Item;
-import net.minecraft.nbt.JsonToNBT;
-import net.minecraft.nbt.NBTException;
-import net.minecraft.nbt.NBTTagCompound;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -17,6 +8,15 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+import editmobdrops.handlers.ConfigHandler;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
+import net.minecraft.item.Item;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTException;
+import net.minecraft.nbt.NBTTagCompound;
 
 public class AddedDrop {
 	public boolean valid = false;

--- a/src/main/java/editmobdrops/EditMobDrops.java
+++ b/src/main/java/editmobdrops/EditMobDrops.java
@@ -1,5 +1,7 @@
 package editmobdrops;
 
+import java.io.File;
+
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
@@ -9,8 +11,6 @@ import editmobdrops.commands.ReloadConfigCommand;
 import editmobdrops.handlers.ConfigHandler;
 import editmobdrops.handlers.LivingDropsEventHandler;
 import net.minecraftforge.common.MinecraftForge;
-
-import java.io.File;
 
 @Mod(modid = Reference.MODID, name = Reference.NAME, version = Reference.VERSION, acceptableRemoteVersions = "*")
 public class EditMobDrops {

--- a/src/main/java/editmobdrops/commands/ReloadConfigCommand.java
+++ b/src/main/java/editmobdrops/commands/ReloadConfigCommand.java
@@ -1,5 +1,7 @@
 package editmobdrops.commands;
 
+import java.util.List;
+
 import editmobdrops.handlers.ConfigHandler;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
@@ -7,8 +9,6 @@ import net.minecraft.command.PlayerNotFoundException;
 import net.minecraft.command.WrongUsageException;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ChatComponentText;
-
-import java.util.List;
 
 public class ReloadConfigCommand extends CommandBase {
 	public String getCommandName() {

--- a/src/main/java/editmobdrops/handlers/ConfigHandler.java
+++ b/src/main/java/editmobdrops/handlers/ConfigHandler.java
@@ -1,5 +1,10 @@
 package editmobdrops.handlers;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import cpw.mods.fml.client.event.ConfigChangedEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import editmobdrops.AddedDrop;
@@ -7,11 +12,6 @@ import editmobdrops.Reference;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraftforge.common.config.Configuration;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class ConfigHandler {
 	public static Configuration config;

--- a/src/main/java/editmobdrops/handlers/LivingDropsEventHandler.java
+++ b/src/main/java/editmobdrops/handlers/LivingDropsEventHandler.java
@@ -1,5 +1,9 @@
 package editmobdrops.handlers;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import editmobdrops.AddedDrop;
@@ -15,12 +19,16 @@ import net.minecraft.entity.monster.EntitySlime;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import net.minecraftforge.event.world.WorldEvent.Load;
 
 public class LivingDropsEventHandler {
+	
+	// Refreshes configs on world load in order to capture items that weren't available during FMLPostInitializationEvent
+	@SubscribeEvent
+	public void onWorldLoad(Load event) {
+		ConfigHandler.reloadConfig();
+	}
+	
 	// A method to handle LivingDropsEvents
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public void onMobDrops(LivingDropsEvent event) {


### PR DESCRIPTION
Now the configs will reload, similarly to running the command, on world load. This should solve the issue of improperly caching items that were not registered during initialization.

Additionally I've cleaned up imports and set random to the world seed.

Version number was changed to 1.4.3