### PR TITLE
Add world load event to refresh configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = "1.4.2"
+version = "1.4.3"
 group = "editmobdrops"
 archivesBaseName = "editmobdrops-1.12.2"
 

--- a/src/main/java/editmobdrops/AddedDrop.java
+++ b/src/main/java/editmobdrops/AddedDrop.java
@@ -1,14 +1,5 @@
 package editmobdrops;
 
-import editmobdrops.handlers.ConfigHandler;
-import net.minecraft.entity.Entity;
-import net.minecraft.item.Item;
-import net.minecraft.nbt.JsonToNBT;
-import net.minecraft.nbt.NBTException;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.common.registry.ForgeRegistries;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -17,6 +8,15 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import editmobdrops.handlers.ConfigHandler;
+import net.minecraft.entity.Entity;
+import net.minecraft.item.Item;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTException;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
 public class AddedDrop {
 	public boolean valid = false;

--- a/src/main/java/editmobdrops/EditMobDrops.java
+++ b/src/main/java/editmobdrops/EditMobDrops.java
@@ -1,5 +1,7 @@
 package editmobdrops;
 
+import java.io.File;
+
 import editmobdrops.commands.ReloadConfigCommand;
 import editmobdrops.handlers.ConfigHandler;
 import editmobdrops.handlers.LivingDropsEventHandler;
@@ -9,8 +11,6 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
-
-import java.io.File;
 
 @Mod(modid = Reference.MODID, name = Reference.NAME, version = Reference.VERSION, acceptableRemoteVersions = "*")
 public class EditMobDrops {

--- a/src/main/java/editmobdrops/Reference.java
+++ b/src/main/java/editmobdrops/Reference.java
@@ -4,5 +4,5 @@ public class Reference {
 	// Reference data
 	public static final String MODID = "editmobdrops";
 	public static final String NAME = "Edit Mob Drops";
-	public static final String VERSION = "1.4.2";
+	public static final String VERSION = "1.4.3";
 }

--- a/src/main/java/editmobdrops/commands/ReloadConfigCommand.java
+++ b/src/main/java/editmobdrops/commands/ReloadConfigCommand.java
@@ -1,13 +1,18 @@
 package editmobdrops.commands;
 
+import java.util.List;
+
+import javax.annotation.Nullable;
+
 import editmobdrops.handlers.ConfigHandler;
-import net.minecraft.command.*;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.PlayerNotFoundException;
+import net.minecraft.command.WrongUsageException;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
-
-import javax.annotation.Nullable;
-import java.util.List;
 
 public class ReloadConfigCommand extends CommandBase {
 	public String getName() {

--- a/src/main/java/editmobdrops/handlers/ConfigHandler.java
+++ b/src/main/java/editmobdrops/handlers/ConfigHandler.java
@@ -1,5 +1,10 @@
 package editmobdrops.handlers;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import editmobdrops.AddedDrop;
 import editmobdrops.Reference;
 import net.minecraft.entity.Entity;
@@ -8,11 +13,6 @@ import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class ConfigHandler {
 	public static Configuration config;

--- a/src/main/java/editmobdrops/handlers/LivingDropsEventHandler.java
+++ b/src/main/java/editmobdrops/handlers/LivingDropsEventHandler.java
@@ -1,5 +1,14 @@
 package editmobdrops.handlers;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
 import editmobdrops.AddedDrop;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -12,24 +21,25 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.JsonToNBT;
 import net.minecraft.nbt.NBTException;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
+import net.minecraftforge.event.world.WorldEvent.Load;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-
 public class LivingDropsEventHandler {
-	Random random = new Random();
-
+//	Random random = new Random();
+	
+	// Refreshes configs on world load in order to capture items that weren't available during FMLPostInitializationEvent
+	@SubscribeEvent
+	public void onWorldLoad(Load event) {
+		ConfigHandler.reloadConfig();
+	}
+		
 	// A method to handle LivingDropsEvents
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public void onMobDrops(LivingDropsEvent event) {
+		
+		Random random = event.getEntityLiving().world.rand;
+		
 		// Setting up variables to make things easier
 		EntityLivingBase entityKilled = event.getEntityLiving();
 		List<ItemStack> itemsToDrop = new ArrayList<>();
@@ -46,7 +56,7 @@ public class LivingDropsEventHandler {
 				if (ConfigHandler.debugMode) {
 					System.out.println("Adding " + itemToAdd.item);
 				}
-				ItemStack itemstack = new ItemStack(itemToAdd.item, randomStackSize(itemToAdd), itemToAdd.metadata);
+				ItemStack itemstack = new ItemStack(itemToAdd.item, randomStackSize(itemToAdd, random), itemToAdd.metadata);
 				if (itemToAdd.nbtTag != null) {
 					itemstack.setTagCompound(itemToAdd.nbtTag);
 				}
@@ -60,7 +70,7 @@ public class LivingDropsEventHandler {
 					if (ConfigHandler.debugMode) {
 						System.out.println("Adding " + itemToAdd.item);
 					}
-					ItemStack itemstack = new ItemStack(itemToAdd.item, randomStackSize(itemToAdd), itemToAdd.metadata);
+					ItemStack itemstack = new ItemStack(itemToAdd.item, randomStackSize(itemToAdd, random), itemToAdd.metadata);
 					if (itemToAdd.nbtTag != null) {
 						itemstack.setTagCompound(itemToAdd.nbtTag);
 					}
@@ -75,7 +85,7 @@ public class LivingDropsEventHandler {
 					if (ConfigHandler.debugMode) {
 						System.out.println("Adding " + itemToAdd.item);
 					}
-					ItemStack itemstack = new ItemStack(itemToAdd.item, randomStackSize(itemToAdd), itemToAdd.metadata);
+					ItemStack itemstack = new ItemStack(itemToAdd.item, randomStackSize(itemToAdd, random), itemToAdd.metadata);
 					if (itemToAdd.nbtTag != null) {
 						itemstack.setTagCompound(itemToAdd.nbtTag);
 					}
@@ -92,7 +102,7 @@ public class LivingDropsEventHandler {
 							if (ConfigHandler.debugMode) {
 								System.out.println("Adding " + itemToAdd.item);
 							}
-							ItemStack itemstack = new ItemStack(itemToAdd.item, randomStackSize(itemToAdd), itemToAdd.metadata);
+							ItemStack itemstack = new ItemStack(itemToAdd.item, randomStackSize(itemToAdd, random), itemToAdd.metadata);
 							if (itemToAdd.nbtTag != null) {
 								itemstack.setTagCompound(itemToAdd.nbtTag);
 							}
@@ -110,7 +120,7 @@ public class LivingDropsEventHandler {
 					// Adding the item
 					if (ConfigHandler.debugMode)
 						System.out.println("Adding " + singleMobItem.item);
-					ItemStack itemstack = new ItemStack(singleMobItem.item, randomStackSize(singleMobItem), singleMobItem.metadata);
+					ItemStack itemstack = new ItemStack(singleMobItem.item, randomStackSize(singleMobItem, random), singleMobItem.metadata);
 					if (singleMobItem.nbtTag != null) {
 						itemstack.setTagCompound(singleMobItem.nbtTag);
 					}
@@ -147,7 +157,7 @@ public class LivingDropsEventHandler {
 		return itemstack;
 	}
 
-	private int randomStackSize(AddedDrop drop) {
+	private int randomStackSize(AddedDrop drop, Random random) {
 		if (drop.minStack < drop.maxStack) {
 			return random.nextInt(1 + drop.maxStack - drop.minStack) + drop.minStack;
 		} else {


### PR DESCRIPTION
Now the configs will reload, similarly to running the command, on world load. This should solve the issue of improperly caching items that were not registered during initialization.

Additionally I've cleaned up imports and set random to the world seed.

Version number was changed to 1.4.3